### PR TITLE
fix(Window): When the dock is on the right, the position is not close

### DIFF
--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -241,6 +241,7 @@ void WindowedFrame::showLauncher()
         m_appsManager->refreshAllList();
     }
 
+    adjustSize(); // right widget need calculate width based on font
     adjustPosition();
     show();
 


### PR DESCRIPTION
dock在右边时，启动launcher会看到launcher没有贴近dock。

launcher的右边是根据字号来计算宽度的，所以需要调用adjustSize先计算一下。