### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,19 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-launcher.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-launcher.spec
+    - .packit.yaml
+
+upstream_package_name: dde-launcher
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-launcher
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-launcher.spec"
+  post-upstream-clone: |
+    cp rpm/dde-launcher.spec rpm/deepin-launcher.spec

--- a/rpm/dde-launcher.spec
+++ b/rpm/dde-launcher.spec
@@ -1,12 +1,22 @@
+%global repo dde-launcher
 %global sname deepin-launcher
 
-Name:           dde-launcher
-Version:        5.1.0.6
-Release:        1
+%if 0%{?fedora}
+Name:           %{sname}
+%else
+Name:           %{repo}
+%endif
+Version:        5.3.0.27
+Release:        1%{?fedora:%dist}
 Summary:        Deepin desktop-environment - Launcher module
 License:        GPLv3
+%if 0%{?fedora}
+URL:            https://github.com/linuxdeepin/dde-launcher
+Source0:        %{url}/archive/%{version}/%{repo}-%{version}.tar.gz
+%else
 URL:            http://shuttle.corp.deepin.com/cache/repos/eagle/release-candidate/RERFNS4wLjAuNjU3NQ/pool/main/d/dde-launcher/
 Source0:        %{name}_%{version}.orig.tar.xz	
+%endif
 
 BuildRequires:  cmake
 BuildRequires:  cmake(Qt5LinguistTools)
@@ -22,7 +32,11 @@ BuildRequires:  pkgconfig(Qt5X11Extras)
 BuildRequires:  qt5-qtbase-private-devel
 %{?_qt5:Requires: %{_qt5}%{?_isa} = %{_qt5_version}}
 Requires:       deepin-menu
+%if 0%{?fedora}
+Requires:       deepin-daemon
+%else
 Requires:       dde-daemon
+%endif
 Requires:       startdde
 Requires:       hicolor-icon-theme
 
@@ -37,25 +51,34 @@ Requires:       %{name}%{?_isa} = %{version}-%{release}
 Header files and libraries for %{sname}.
 
 %prep
-%setup -q -n %{name}-%{version}
-sed -i 's|lrelease|lrelease-qt5|' translate_generation.sh
+%autosetup -p1 -n %{repo}-%{version}
 
 %build
+sed -i 's|lrelease|lrelease-qt5|' translate_generation.sh
+%if 0%{?fedora}
+%cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} -DWITHOUT_UNINSTALL_APP=1
+%cmake_build
+%else
 %cmake -DCMAKE_INSTALL_PREFIX=%{_prefix} -DWITHOUT_UNINSTALL_APP=1 .
 %make_build
+%endif
 
 %install
+%if 0%{?fedora}
+%cmake_install
+%else
 %make_install INSTALL_ROOT=%{buildroot}
+%endif
 
 %files
 %license LICENSE
-%{_bindir}/%{name}
-%{_datadir}/%{name}/
+%{_bindir}/%{repo}
+%{_datadir}/%{repo}/
 %{_datadir}/dbus-1/services/*.service
 %{_datadir}/icons/hicolor/scalable/apps/%{sname}.svg
 
 %files devel
-%{_includedir}/%{name}/
+%{_includedir}/%{repo}/
 
 %changelog
 * Wed Jun 10 2020 uoser <uoser@uniontech.com> - 5.1.0.6


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>