### PR TITLE
feat: add use-workspace-background gsetting

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -7,7 +7,8 @@ arch=('x86_64' 'aarch64')
 url="https://github.com/linuxdeepin/dde-launcher"
 license=('GPL3')
 depends=('gsettings-qt' 'qt5-svg' 'qt5-x11extras' 'startdde-git' 'deepin-daemon-git' 'deepin-qt-dbus-factory-git' 'xdg-user-dirs')
-makedepends=('git' 'cmake' 'ninja' 'gtest' 'qt5-tools' 'qt5-base' 'qt5-x11extras' 'qt5-svg' 'dtkwidget-git' 'gtest' 'gmock')
+makedepends=('git' 'cmake' 'ninja' 'gtest' 'qt5-tools' 'qt5-base' 'qt5-x11extras'
+             'qt5-svg' 'dtkwidget-git' 'gtest' 'gmock' 'dtkcommon-git' 'dtkcore-git')
 conflicts=('deepin-launcher')
 provides=('deepin-launcher')
 groups=('deepin-git')


### PR DESCRIPTION
Support the mode that use the workspace wallpaper, and further, it should also support the transparent mode.
Note that this submission will not reduce memory pressure, only the interface effect.

Log:
Issue: Closes linuxdeepin/developer-center#2588