### PR TITLE
fix: 修复小窗模式下滚动动画被连续打断的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ build*
 .vscode
 .transifexrc
 lupdate.sh
+
+CMakeLists.txt.user

--- a/src/view/applistview.cpp
+++ b/src/view/applistview.cpp
@@ -48,14 +48,14 @@ AppListView::AppListView(QWidget *parent)
     : DListView(parent)
     , m_dropThresholdTimer(new QTimer(this))
     , m_touchMoveFlag(false)
-    , m_scrollAni(new QPropertyAnimation(verticalScrollBar(), "value", this))
+    , m_scrollbar(new SmoothScrollBar)
     , m_updateEnableSelectionByMouseTimer(nullptr)
     , m_updateEnableShowSelectionByMouseTimer(nullptr)
 {
     this->setAccessibleName("Form_AppList");
     viewport()->setAutoFillBackground(false);
-    m_scrollAni->setEasingCurve(QEasingCurve::OutQuint);
-    m_scrollAni->setDuration(800);
+
+    setVerticalScrollBar(m_scrollbar);
 
     horizontalScrollBar()->setEnabled(false);
     setFocusPolicy(Qt::NoFocus);
@@ -85,8 +85,8 @@ AppListView::AppListView(QWidget *parent)
     connect(m_dropThresholdTimer, &QTimer::timeout, this, &AppListView::dropSwap);
 #endif
 
-    connect(m_scrollAni, &QPropertyAnimation::valueChanged, this, &AppListView::handleScrollValueChanged);
-    connect(m_scrollAni, &QPropertyAnimation::finished, this, &AppListView::handleScrollFinished);
+    connect(m_scrollbar, &SmoothScrollBar::valueChanged, this, &AppListView::handleScrollValueChanged);
+    connect(m_scrollbar, &SmoothScrollBar::scrollFinish, this, &AppListView::handleScrollFinished);
 }
 
 const QModelIndex AppListView::indexAt(const int index) const
@@ -100,16 +100,7 @@ const QModelIndex AppListView::indexAt(const int index) const
  */
 void AppListView::wheelEvent(QWheelEvent *e)
 {
-    // 解决蓝牙连接时触摸板斜对角方向双指按住滑动时滑条滚动异常问题
-    if (e->orientation() == Qt::Horizontal)
-        return;
-
-    int offset = -e->delta();
-
-    m_scrollAni->stop();
-    m_scrollAni->setStartValue(verticalScrollBar()->value());
-    m_scrollAni->setEndValue(verticalScrollBar()->value() + offset * m_speedTime);
-    m_scrollAni->start();
+    m_scrollbar->scrollSmooth(-e->angleDelta().y() * m_speedTime);
 }
 
 void AppListView::mouseMoveEvent(QMouseEvent *e)
@@ -167,7 +158,7 @@ void AppListView::mousePressEvent(QMouseEvent *e)
 
     if (e->source() == Qt::MouseEventSynthesizedByQt) {
         emit requestEnter(false);
-        m_scrollAni->stop();
+        m_scrollbar->stopScroll();
 
         if (m_updateEnableShowSelectionByMouseTimer) {
             m_updateEnableShowSelectionByMouseTimer->stop();
@@ -243,10 +234,7 @@ void AppListView::mouseReleaseEvent(QMouseEvent *e)
 
         const auto wheelSpeed = inPutInter.property("WheelSpeed").toInt();
         int offset = m_lastTouchBeginPos.y() - e->pos().y();
-        m_scrollAni->stop();
-        m_scrollAni->setStartValue(verticalScrollBar()->value());
-        m_scrollAni->setEndValue(verticalScrollBar()->value() + offset * wheelSpeed);
-        m_scrollAni->start();
+        m_scrollbar->scrollSmooth(offset * wheelSpeed);
         QScroller::scroller(this)->deleteLater();
         return;
     }

--- a/src/view/applistview.h
+++ b/src/view/applistview.h
@@ -30,6 +30,8 @@
 #include <DWindowManagerHelper>
 #include <DListView>
 
+#include "widgets/smoothscrollbar.h"
+
 #define DRAG_SCROLL_THRESHOLD 25
 
 DGUI_USE_NAMESPACE
@@ -85,7 +87,7 @@ private:
     bool m_touchMoveFlag;                               // 代表触摸屏移动操作
 
     QPropertyAnimation *m_lastFakeAni = nullptr;
-    QPropertyAnimation *m_scrollAni;
+    SmoothScrollBar *m_scrollbar;
     double m_speedTime = 1.0;
 
     QTimer *m_updateEnableSelectionByMouseTimer;        // 限制拖拽时间不能少于200ms

--- a/src/widgets/smoothscrollbar.cpp
+++ b/src/widgets/smoothscrollbar.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 ~ 2018 Deepin Technology Co., Ltd.
+ *
+ * Author:     Maicss <maicss@126.com>
+ *
+ * Maintainer: Maicss <maicss@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "smoothscrollbar.h"
+#include <QPropertyAnimation>
+
+SmoothScrollBar::SmoothScrollBar(QWidget *parent) : QScrollBar(parent)
+  ,m_propertyAnimation(new QPropertyAnimation(this,"value",this))
+{
+    m_targetValue = value();
+
+    m_propertyAnimation->setDuration(800);
+    m_propertyAnimation->setEasingCurve(QEasingCurve::OutCubic);
+
+    connect(m_propertyAnimation,&QPropertyAnimation::finished,this,&SmoothScrollBar::scrollFinish);
+}
+
+void SmoothScrollBar::setValueSmooth(int value)
+{
+    m_propertyAnimation->stop();
+    m_propertyAnimation->setEndValue(value);
+    m_propertyAnimation->start();
+}
+
+void SmoothScrollBar::scrollSmooth(int value)
+{
+
+    if(m_targetValue > maximum()){
+        m_targetValue = maximum();
+    }else if(m_targetValue < minimum()){
+        m_targetValue = minimum();
+    }
+    m_targetValue += value;
+    setValueSmooth(m_targetValue);
+}
+
+void SmoothScrollBar::stopScroll()
+{
+    m_propertyAnimation->stop();
+    m_targetValue = value();
+}
+

--- a/src/widgets/smoothscrollbar.h
+++ b/src/widgets/smoothscrollbar.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 ~ 2018 Deepin Technology Co., Ltd.
+ *
+ * Author:     Maicss <maicss@126.com>
+ *
+ * Maintainer: Maicss <maicss@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SMOOTHSCROLLBAR_H
+#define SMOOTHSCROLLBAR_H
+
+#include <QWidget>
+#include <QScrollBar>
+#include <QPropertyAnimation>
+
+class SmoothScrollBar : public QScrollBar
+{
+    Q_OBJECT
+public:
+    explicit SmoothScrollBar(QWidget *parent = nullptr);
+
+signals:
+    void scrollFinish();
+
+public slots:
+    void setValueSmooth(int value);
+    void scrollSmooth(int value);
+    void stopScroll();
+
+private:
+    int m_targetValue;
+
+    QPropertyAnimation *m_propertyAnimation;
+};
+
+#endif // SMOOTHSCROLLBAR_H


### PR DESCRIPTION
滚动事件每触发一次就会导致上次未结束的动画提前结束，导致滚动距离达不到预期目标，滚轮滚动越快，列表滚动越慢 ， 本次提交引入了一个平滑滚动条控件，替换了原有的滚动动画方案，解决了此问题。