### PR TITLE
fix: 修复小窗模式下滚动动画被连续打断的问题

### DIFF
--- a/src/view/applistview.h
+++ b/src/view/applistview.h
@@ -30,6 +30,8 @@
 #include <DWindowManagerHelper>
 #include <DListView>
 
+#include "widgets/smoothscrollbar.h"
+
 #define DRAG_SCROLL_THRESHOLD 25
 
 DGUI_USE_NAMESPACE
@@ -87,7 +89,7 @@ private:
     bool m_touchMoveFlag;                               // 代表触摸屏移动操作
 
     QPropertyAnimation *m_lastFakeAni = nullptr;
-    QPropertyAnimation *m_scrollAni;
+    SmoothScrollBar *m_scrollbar;
     double m_speedTime = 1.0;
 
     QTimer *m_updateEnableSelectionByMouseTimer;        // 限制拖拽时间不能少于200ms

--- a/src/widgets/smoothscrollbar.cpp
+++ b/src/widgets/smoothscrollbar.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Deepin Technology Co., Ltd.
+ * Copyright (C) 2022 Maicss <maicss@126.com>
+ *
+ * Author:     Maicss <maicss@126.com>
+ *
+ * Maintainer: Maicss <maicss@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "smoothscrollbar.h"
+#include <QPropertyAnimation>
+
+SmoothScrollBar::SmoothScrollBar(QWidget *parent)
+    : QScrollBar(parent)
+    , m_propertyAnimation(new QPropertyAnimation(this, "value", this))
+{
+    m_targetValue = value();
+
+    m_propertyAnimation->setDuration(800);
+    m_propertyAnimation->setEasingCurve(QEasingCurve::OutCubic);
+
+    connect(m_propertyAnimation, &QPropertyAnimation::finished, this, &SmoothScrollBar::scrollFinished);
+}
+
+void SmoothScrollBar::setValueSmooth(int value)
+{
+    m_propertyAnimation->stop();
+    m_propertyAnimation->setEndValue(value);
+    m_propertyAnimation->start();
+}
+
+void SmoothScrollBar::scrollSmooth(int value)
+{
+    // 这里先对m_targetValue限制是为了实现撞停的效果，否则滚动到上下边缘会减速
+    m_targetValue = qBound(minimum(), m_targetValue, maximum());
+    m_targetValue += value;
+    setValueSmooth(m_targetValue);
+}
+
+void SmoothScrollBar::stopScroll()
+{
+    m_propertyAnimation->stop();
+    m_targetValue = value();
+}
+

--- a/src/widgets/smoothscrollbar.h
+++ b/src/widgets/smoothscrollbar.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Deepin Technology Co., Ltd.
+ * Copyright (C) 2022 Maicss <maicss@126.com>
+ *
+ * Author:     Maicss <maicss@126.com>
+ *
+ * Maintainer: Maicss <maicss@126.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SMOOTHSCROLLBAR_H
+#define SMOOTHSCROLLBAR_H
+
+#include <QWidget>
+#include <QScrollBar>
+#include <QPropertyAnimation>
+
+class SmoothScrollBar : public QScrollBar
+{
+    Q_OBJECT
+public:
+    explicit SmoothScrollBar(QWidget *parent = nullptr);
+
+signals:
+    void scrollFinished();
+
+public slots:
+    void setValueSmooth(int value);
+    void scrollSmooth(int value);
+    void stopScroll();
+
+private:
+    int m_targetValue;
+
+    QPropertyAnimation *m_propertyAnimation;
+};
+
+#endif // SMOOTHSCROLLBAR_H


### PR DESCRIPTION
滚动事件每触发一次就会导致上次未结束的动画提前结束，导致滚动距离达不到预期目标，滚 轮滚动越快，列表滚动越慢 ，本次提交引入了一个平滑滚动条控件，替换了原有的滚动动画方案，解决了此问题。