### PR TITLE
fix: 仅HDMI屏拔掉HDMI显示屏，启动器位置显示异常

### DIFF
--- a/src/windowedframe.h
+++ b/src/windowedframe.h
@@ -51,7 +51,7 @@ DWIDGET_USE_NAMESPACE
 
 using Appearance = com::deepin::daemon::Appearance;
 class QLabel;
-
+class DBusDockInterface;
 class WindowedFrame : public DBlurEffectWidget, public LauncherInterface
 {
     Q_OBJECT
@@ -129,7 +129,7 @@ private slots:
     void prepareHideLauncher();
     void recoveryAll();
     void onOpacityChanged(const double value);
-    void onScreenInfoChange();
+    void onDockInfoChange();
     void updatePosition();
     void onHideMenu();
 
@@ -165,7 +165,7 @@ private:
     ModeToggleButton *m_modeToggleBtn;   // 小窗口右上角窗口模式切换按钮
     DSearchEdit *m_searcherEdit;         // 搜索控件
     bool m_enterSearchEdit;
-    const QScreen *m_curScreen;
+    const DBusDockInterface *m_dockFrontInfc = nullptr;
 };
 
 #endif // WINDOWEDFRAME_H


### PR DESCRIPTION
启动器的位置跟随 dock 的位置，那么就应该根据
dock 的 geometrychanged 来修正自己的位置，dock
的接口如果返回错误那么 dock 中修改，而不是在
启动器中去矫正。

Log:
Bug: https://pms.uniontech.com/bug-view-127439.html
Influence: wayland + 缩放多屏 + 启动器位置
Change-Id: Id794c68a916283f223cf23d8991e5d8a7dc76091