### PR TITLE
fix: 修复wayland下多次右键菜单时界面自动隐藏的问题

### DIFF
--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -816,7 +816,9 @@ bool WindowedFrame::eventFilter(QObject *watched, QEvent *event)
             m_searcherEdit->lineEdit()->clearFocus();
     }
 
-    if (isActiveWindow() && watched == qApp && event->type() == QEvent::ApplicationDeactivate) {
+    // 第一次弹出菜单时会将界面设置为ApplicationDeactivate状态，导致再次弹出菜单时会满足条件从而隐藏界面
+    // 此时需要判断下是否因为弹出菜单导致的界面ApplicationDeactivate状态
+    if (isActiveWindow() && watched == qApp && event->type() == QEvent::ApplicationDeactivate && !m_menuWorker->isMenuShown()) {
         hideLauncher();
     }
     return QWidget::eventFilter(watched, event);


### PR DESCRIPTION
第一次弹出菜单时会将界面设置为ApplicationDeactivate状态，再次弹出菜单时会隐藏界面
因此需要隐藏界面时判断下是否是弹出菜单导致的ApplicationDeactivate状态
否则不隐藏

Log: 修复wayland下多次右键弹出菜单时界面自动隐藏的问题
Bug: https://pms.uniontech.com/bug-view-150143.html
Influence: wayland下多次右键菜单时界面不会自动隐藏
Change-Id: Idebacba1782d075d7168a31dd5234235c4a1242b