### PR TITLE
fix: 处理启动器右键选中效果的交互逻辑

### DIFF
--- a/src/fullscreenframe.h
+++ b/src/fullscreenframe.h
@@ -227,5 +227,6 @@ private:
     int m_scrollStart;                                  // 鼠标按下时滑动区域停留的数值
     QTime *m_changePageDelayTime;                       // 滚动延时，设定时间内只允许滚动一次
     const QScreen *m_curScreen;
+    bool m_bMenuDisplayState;
 };
 #endif // MAINFRAME_H

--- a/src/model/appslistmodel.cpp
+++ b/src/model/appslistmodel.cpp
@@ -355,7 +355,6 @@ const QModelIndex AppsListModel::indexAt(const QString &appKey) const
 
 void AppsListModel::setDrawBackground(bool draw)
 {
-    Q_EMIT notifyDrawBackgroundChanged();
     if (draw == m_drawBackground) return;
 
     m_drawBackground = draw;

--- a/src/model/appslistmodel.h
+++ b/src/model/appslistmodel.h
@@ -114,9 +114,6 @@ public:
 
     void setDrawBackground(bool draw);
 
-Q_SIGNALS:
-    void notifyDrawBackgroundChanged();
-
 public slots:
     void clearDraggingIndex();
     void setCategory(const AppCategory category);

--- a/src/view/applistview.cpp
+++ b/src/view/applistview.cpp
@@ -51,6 +51,7 @@ AppListView::AppListView(QWidget *parent)
     , m_scrollAni(new QPropertyAnimation(verticalScrollBar(), "value", this))
     , m_updateEnableSelectionByMouseTimer(nullptr)
     , m_updateEnableShowSelectionByMouseTimer(nullptr)
+    , m_bMenuVisible(false)
 {
     this->setAccessibleName("Form_AppList");
     viewport()->setAutoFillBackground(false);
@@ -94,6 +95,15 @@ const QModelIndex AppListView::indexAt(const int index) const
     return model()->index(index, 0, QModelIndex());
 }
 
+void AppListView::setMenuVisible(bool value)
+{
+    if (value == m_bMenuVisible) {
+        return;
+    }
+    m_bMenuVisible = value;
+    Q_EMIT notifyMenuVisibleChanged(value);
+}
+
 /**
  * @brief AppListView::wheelEvent 鼠标滑轮事件触发滑动区域控件动画
  * @param e 鼠标滑轮事件指针对象
@@ -114,6 +124,10 @@ void AppListView::wheelEvent(QWheelEvent *e)
 
 void AppListView::mouseMoveEvent(QMouseEvent *e)
 {
+    if (m_bMenuVisible) {
+        return;
+    }
+
     if (e->source() == Qt::MouseEventSynthesizedByQt) {
         m_touchMoveFlag = true;
 

--- a/src/view/applistview.h
+++ b/src/view/applistview.h
@@ -43,6 +43,7 @@ public:
 
     using DListView::indexAt;
     const QModelIndex indexAt(const int index) const;
+    void setMenuVisible(bool value);
 
 signals:
     void popupMenuRequested(const QPoint &pos, const QModelIndex &index) const;
@@ -51,6 +52,7 @@ signals:
     void requestScrollStop() const;
     void requestSwitchToCategory(const QModelIndex &index) const;
     void requestEnter(bool enter) const;
+    void notifyMenuVisibleChanged(bool) const;
 
 public slots:
     void menuHide();
@@ -91,6 +93,7 @@ private:
     QTimer *m_updateEnableSelectionByMouseTimer;        // 限制拖拽时间不能少于200ms
     QTimer *m_updateEnableShowSelectionByMouseTimer;    // 检测按压是否现实选择灰色背景
     QPoint m_lastTouchBeginPos;
+    bool m_bMenuVisible;
 };
 
 #endif // APPLISTVIEW_H

--- a/src/worker/menudialog.cpp
+++ b/src/worker/menudialog.cpp
@@ -117,6 +117,8 @@ void Menu::showEvent(QShowEvent *event)
     QTimer::singleShot(10, this, [ = ] {
         m_monitor->blockSignals(false);
     });
+
+    Q_EMIT notifyMenuDisplayState(true);
 }
 
 void Menu::hideEvent(QHideEvent *event)
@@ -124,6 +126,7 @@ void Menu::hideEvent(QHideEvent *event)
     QMenu::hideEvent(event);
 
     m_monitor->blockSignals(true);
+    Q_EMIT notifyMenuDisplayState(false);
 }
 
 void Menu::moveDown(int size)

--- a/src/worker/menudialog.h
+++ b/src/worker/menudialog.h
@@ -51,6 +51,9 @@ private:
     void moveUp(int size = 0);
     void openItem();
 
+Q_SIGNALS:
+    void notifyMenuDisplayState(bool);
+
 private Q_SLOTS:
     void onButtonPress();
 

--- a/src/worker/menuworker.cpp
+++ b/src/worker/menuworker.cpp
@@ -44,6 +44,7 @@ MenuWorker::MenuWorker(QObject *parent)
     , m_isItemEnableScaling(false)
     , m_menu(new Menu)
 {
+    connect(m_menu, &Menu::notifyMenuDisplayState, this, &MenuWorker::notifyMenuDisplayState);
 }
 
 MenuWorker::~MenuWorker()
@@ -187,22 +188,6 @@ bool MenuWorker::isMenuVisible()
         return m_menu->isVisible();
     else
         return false;
-}
-
-void MenuWorker::setMenuVisible(const bool &state)
-{
-    if (!m_menu) {
-        return;
-    }
-    m_menu->setVisible(state);
-}
-
-bool MenuWorker::getMenuVisible()
-{
-    if (m_menu) {
-        return m_menu->isVisible();
-    }
-    return false;
 }
 
 void MenuWorker::showMenuByAppItem(QPoint pos, const QModelIndex &index)

--- a/src/worker/menuworker.h
+++ b/src/worker/menuworker.h
@@ -70,14 +70,13 @@ public:
     QRect menuGeometry() const {return m_menuGeometry;}
     void creatMenuByAppItem(QMenu *menu, QSignalMapper *signalMapper);
     bool isMenuVisible();
-    bool getMenuVisible();
-    void setMenuVisible(const bool &state);
 
 signals:
     void appLaunched();
     void menuAccepted();
     void unInstallApp(const QModelIndex &index);
     void menuShowMouseMoving();
+    void notifyMenuDisplayState(bool);
 
 public slots:
     void showMenuByAppItem(QPoint pos, const QModelIndex &index);


### PR DESCRIPTION
当右键菜单出来后，左边的选中项在鼠标再移动过去的时候不再变化
直到菜单消失后，鼠标选中效果才出现

Log: 启动器选中效果变更
Influence: 右键菜单
Bug: https://pms.uniontech.com/bug-view-152801.html
Change-Id: I994c11b7c836a140331ab349f12bccdd5dbd20e1