### PR TITLE
fix: 设置菜单界面类型为Popup修复菜单圆角问题

### DIFF
--- a/src/worker/menudialog.cpp
+++ b/src/worker/menudialog.cpp
@@ -39,7 +39,7 @@ using XEventMonitor = com::deepin::api::XEventMonitor;
 Menu::Menu(QWidget *parent)
     : QMenu(parent)
 {
-    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint | Qt::Dialog);
+    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint | Qt::Popup);
     setAccessibleName("popmenu");
     setObjectName("rightMenu");
     qApp->installEventFilter(this);


### PR DESCRIPTION
将菜单界面设置为Popup类型，修复圆角不生效问题

Log: 修复在启动器中选中应用并鼠标右键，显示窗口为直角问题
Bug: https://pms.uniontech.com/bug-view-152599.html
Influence: 应用右键菜单显示圆角