### PR TITLE
chore: build on newer debian release

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Depends:
  dde-daemon (>=5.13.12),
  startdde (>=5.8.9),
  lastore-daemon (>=5.2.9),
- libxcb-util0,
+ libxcb-util0 | libxcb-util1,
  ${misc:Depends},
  ${shlibs:Depends},
 Conflicts:


### PR DESCRIPTION
更新依赖描述（`libxcb-util0` -> `libxcb-util1`），使可以在新版 debian 中顺利构建。（注：在 v20 停止支持后，可考虑移除 libxcb-util0 依赖）

是处理 https://github.com/linuxdeepin/developer-center/issues/3230 问题的一部分。