### PR TITLE
fix: 应用选中状态优化

### DIFF
--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -805,8 +805,14 @@ bool WindowedFrame::eventFilter(QObject *watched, QEvent *event)
         setFixedSize(m_rightWidget->width() + m_leftBar->width(), 538);
     }
 
-    if(watched == m_appsView && event->type() == QEvent::Wheel) {
-        m_searcherEdit->lineEdit()->clearFocus();
+    if (watched == m_appsView) {
+        if (event->type() == QEvent::Wheel) {
+            m_searcherEdit->lineEdit()->clearFocus();
+        } else if (event->type() == QEvent::Leave && !m_menuWorker->isMenuVisible()) {
+            // 菜单未显示时鼠标移出列表区域，取消应用选中状态，显示菜单时，移动鼠标菜单保持显示并且左侧图标不显示选中状态
+            m_appsModel->setDrawBackground(false);
+            m_searchModel->setDrawBackground(false);
+        }
     }
 
     if (m_enterSearchEdit && watched->objectName() == QString("MiniFrameWindow")) {


### PR DESCRIPTION
未显示应用菜单时，鼠标移出列表区域，取消应用选中状态;
显示应用菜单时，移动鼠标菜单保持显示并且左侧图标不显示选中状态。

Log: 修复窗口模式下同时显示两个选中状态问题
Bug: https://pms.uniontech.com/bug-view-154851.html
Influence: 应用选择中状态优化