### PR TITLE
fix: 当任务栏位置在左侧时，启动器全屏模式下无法展示右上角"展开"按钮

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build*
 .vscode
 .transifexrc
 lupdate.sh
+
+# clangd
+.cache

--- a/src/fullscreenframe.cpp
+++ b/src/fullscreenframe.cpp
@@ -1620,12 +1620,12 @@ void FullScreenFrame::updateDockPosition()
         m_searchWidget->setRightSpacing(0);
         break;
     case DLauncher::DOCK_POS_LEFT:
-        m_searchWidget->setLeftSpacing(dockGeometry.width());
-        m_searchWidget->setRightSpacing(0);
+        m_searchWidget->setRightSpacing(dockGeometry.width());
+        m_searchWidget->setLeftSpacing(0);
         break;
     case DLauncher::DOCK_POS_RIGHT:
-        m_searchWidget->setLeftSpacing(0);
-        m_searchWidget->setRightSpacing(dockGeometry.width());
+        m_searchWidget->setRightSpacing(0);
+        m_searchWidget->setLeftSpacing(dockGeometry.width());
         break;
     default:
         break;


### PR DESCRIPTION
spacing位置设置错误,当dock在左边应该设置右边spacing
为0,右边时候设置左边spacing为0

Log:当dock在左边时候依然设置了左边的spacing,右边设置了右边

BUG: https://pms.uniontech.com/bug-view-155053.html
