### PR TITLE
fix: 调整搜索状态下的交互

### DIFF
--- a/src/fullscreenframe.cpp
+++ b/src/fullscreenframe.cpp
@@ -548,6 +548,9 @@ void FullScreenFrame::showTips(const QString &tips)
 
 void FullScreenFrame::hideTips()
 {
+    if (m_displayMode == SEARCH)
+        m_appItemDelegate->setCurrentIndex(m_multiPagesView->getAppItem(0));
+
     m_tipsLabel->setVisible(false);
 }
 

--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -989,6 +989,9 @@ void WindowedFrame::showTips(const QString &text)
 
 void WindowedFrame::hideTips()
 {
+    if (m_searchModel == m_appsView->model() && m_appsView->count())
+        m_appsView->setCurrentIndex(m_appsView->indexAt(0));
+
     m_tipsLabel->setVisible(false);
 }
 


### PR DESCRIPTION
有搜索内容，且有搜索结果，默认选中第一项；
非搜索状态，或搜索框文本为空时，不选中任何项；

Log: 调整交互
Task: https://pms.uniontech.com/story-view-23419.html