### PR TITLE
fix: 修复启动器全屏壁纸不跟随桌面更新的问题

### DIFF
--- a/src/boxframe/backgroundmanager.cpp
+++ b/src/boxframe/backgroundmanager.cpp
@@ -121,12 +121,14 @@ void BackgroundManager::updateBlurBackgrounds()
 
     QString screenName = screen->name();
 
-    if (isWaylandDisplay()) {
+    /* wayland下使用QScreen获取屏幕名称存在为空的情况，因此使用后端服务获取屏幕名称
+    wayland下 当正常接入主机并显示，当显示模式为复制模式且屏幕名称为空时，更新屏幕的名称，否则直接使用任务栏所在屏幕的名称*/
+    if (isWaylandDisplay() && screenName.isEmpty()) {
         const QList<QDBusObjectPath> monitorList = m_displayInter->monitors();
         for (int i = 0; i < monitorList.size(); i++) {
             DisplayMonitor monitor(DisplayInterface, QString("%1").arg(monitorList.at(i).path()), QDBusConnection::sessionBus(), this);
-            // wayland下 正常接入主机且显示, 当屏幕左上角坐标一致时, 获取屏幕名称
-            if ((monitor.enabled() == true) && (monitor.x() == screen->geometry().x()) && (monitor.y() == screen->geometry().y())) {
+            if ((monitor.enabled() == true) && (monitor.x() == screen->geometry().x())
+                    && (monitor.y() == screen->geometry().y()) && monitor.name() != screenName) {
                 screenName = monitor.name();
                 break;
             }


### PR DESCRIPTION
判断条件错误导致屏幕名称获取异常

Log:
Influence: 启动器-全屏壁纸跟随桌面壁纸更新
Bug: https://pms.uniontech.com/zentao/bug-view-113571.html