### PR TITLE
fix: RightBarButton blur in high scale factor

### DIFF
--- a/src/widgets/miniframebutton.cpp
+++ b/src/widgets/miniframebutton.cpp
@@ -39,7 +39,7 @@ void MiniFrameButton::onThemeTypeChanged(DGuiApplicationHelper::ColorType themeT
 void MiniFrameButton::setIconPath(const QString &path)
 {
     if (!path.isEmpty()) {
-        m_icon = QPixmap(path);
+        setIcon(QIcon(path));
     }
 }
 
@@ -91,8 +91,10 @@ void MiniFrameButton::paintEvent(QPaintEvent *event)
         painter.fillPath(path, m_color);
     }
 
-    if (!m_icon.isNull()) {
-        const QPixmap scaled_pixmap = m_icon.scaled(iconSize().width(), iconSize().height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
-        painter.drawPixmap(rect().center().x() - iconSize().width() / 2 + 1 , rect().center().y() - iconSize().height() / 2 + 1, scaled_pixmap);
+    if (!icon().isNull()) {
+        QRect iconRect;
+        iconRect.setSize(iconSize());
+        iconRect.moveCenter(rect().center());
+        icon().paint(&painter, iconRect);
     }
 }

--- a/src/widgets/miniframebutton.h
+++ b/src/widgets/miniframebutton.h
@@ -38,7 +38,6 @@ protected:
 
 private:
     QColor m_color;
-    QPixmap m_icon;
 };
 
 #endif


### PR DESCRIPTION
  we shouldn't save a pixmap for svg in mutli scale factor scene.
it call QIcon's paint() to paint in device instead of QPainter's drawPixmap(), otherwise, we need to deal with some details， for example deviceRatio.
  if we need to draw some shape to the center of QPainter, we can
call moveCenter(), it is equal to QPoint of
(width / 2 + 1, height / 2 + 1).

Log: 在高缩放比例下，启动器侧边按钮模糊
Bug: https://pms.uniontech.com/bug-view-148759.html
Influence: 在高缩放比例下，启动器侧边按钮模糊
Change-Id: I8786fec0d0537989dee0f3d594196f2004b819fb