### PR TITLE
fix: search and launch app

### DIFF
--- a/src/view/multipagesview.cpp
+++ b/src/view/multipagesview.cpp
@@ -485,7 +485,7 @@ void MultiPagesView::mouseRelease(QMouseEvent *e)
     } else {
         int nScroll = m_appListArea->horizontalScrollBar()->value();
         // 多个分页是点击直接隐藏
-        if (nScroll == m_scrollStart && m_pageCount != 1)
+        if (nScroll == m_scrollStart && m_pageCount != 1 && m_category != AppsListModel::Search)
             emit m_appGridViewList[m_pageIndex]->clicked(QModelIndex());
         else if (nScroll - m_scrollStart > DLauncher::MOUSE_MOVE_TO_NEXT)
             showCurrentPage(m_pageIndex + 1);


### PR DESCRIPTION
原本逻辑当搜索结果页面大于两页时候，逻辑中触发了两次launchapp,
第一次会发送空的modelindex, 清空搜索框，
第二次在原来坐标上触发按钮事件，
这里暂时把逻辑注释，

Log: 搜索
Bugs: https://github.com/linuxdeepin/developer-center/issues/3418

-------

Resolve https://github.com/linuxdeepin/developer-center/issues/3418
