### PR TITLE
fix: 修复启动器全屏模式搜索框删除输入的所有字符,输入光标消失的问题

### DIFF
--- a/src/fullscreenframe.cpp
+++ b/src/fullscreenframe.cpp
@@ -1839,9 +1839,6 @@ void FullScreenFrame::searchTextChanged(const QString &keywords, bool enableUpda
         updateDisplayMode(m_calcUtil->displayMode());
     else
         updateDisplayMode(SEARCH);
-
-    if (m_searchWidget->edit()->lineEdit()->text().isEmpty())
-        m_searchWidget->edit()->lineEdit()->clearFocus();
 }
 
 bool FullScreenFrame::isScrolling()


### PR DESCRIPTION
已与产品确认，改为与窗口模式一样，删除所有搜索字符后，搜索框保持有光标

Log: 修复启动器全屏模式搜索框删除输入的所有字符,输入光标消失的问题
Bug: https://pms.uniontech.com/bug-view-163537.html
Influence: 启动器
Change-Id: I0c3d81966e929c345b859d359f5408c436d51645