### PR TITLE
fix: 修复卸载弹窗危险操作没有使用红色的警示按钮的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build*
 .vscode
 .transifexrc
 lupdate.sh
+.cache/

--- a/src/fullscreenframe.cpp
+++ b/src/fullscreenframe.cpp
@@ -1471,9 +1471,8 @@ void FullScreenFrame::uninstallApp(const QModelIndex &context)
     unInstallDialog.setIcon(appIcon);
     unInstallDialog.setAccessibleName("Imge-unInstallDialog");
 
-    QStringList buttons;
-    buttons << tr("Cancel") << tr("Confirm");
-    unInstallDialog.addButtons(buttons);
+    unInstallDialog.addButton(tr("Cancel"));
+    unInstallDialog.addButton(tr("Confirm"), false, DDialog::ButtonWarning);
 
     connect(&unInstallDialog, &DTK_WIDGET_NAMESPACE::DDialog::buttonClicked, [&](int clickedResult) {
         // 0 means "cancel" button clicked

--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -575,9 +575,8 @@ void WindowedFrame::uninstallApp(const QModelIndex &context)
         }
     }
 
-    QStringList buttons;
-    buttons << tr("Cancel") << tr("Confirm");
-    unInstallDialog.addButtons(buttons);
+    unInstallDialog.addButton(tr("Cancel"));
+    unInstallDialog.addButton(tr("Confirm"), false, DDialog::ButtonWarning);
 
     connect(&unInstallDialog, &DTK_WIDGET_NAMESPACE::DDialog::buttonClicked, [&](int clickedResult) {
         // 0 means "cancel" button clicked


### PR DESCRIPTION
按设计要求，文案“确定”应该为卸载，表达意思更明确

Log: 修复卸载弹窗危险操作没有使用红色的警示按钮的问题
Bug: https://pms.uniontech.com/bug-view-167547.html
Influence: 卸载文案
Change-Id: I340a2b840fc686ebff5c178c3e31134eeecbdb08