### PR TITLE
fix(UI): incorrect category text size and color in windowed frame

### DIFF
--- a/src/delegate/applistdelegate.cpp
+++ b/src/delegate/applistdelegate.cpp
@@ -14,7 +14,9 @@
 #include <QPainter>
 #include <QDebug>
 #include <QApplication>
+#include <DFontSizeManager>
 
+DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
 QT_BEGIN_NAMESPACE
@@ -91,10 +93,14 @@ void AppListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &optio
     painter->setPen(QPen(QPalette().brightText(), 1));
 
     const QString &appName = painter->fontMetrics().elidedText(index.data(AppsListModel::AppNameRole).toString(), Qt::ElideRight, textRect.width());
-    // TODO: 设计搞显示效果偏大
-    // DFontSizeManager::instance()->t8().pixelSize());
-    if (!isTitle)
+
+    if (isTitle) {
+        painter->setOpacity(0.5);
+        painter->setFont(QFont(painter->font().family(), DFontSizeManager::instance()->fontPixelSize(DFontSizeManager::T8)));
+    } else {
+        painter->setOpacity(1);
         painter->setFont(QFont(painter->font().family(), DLauncher::DEFAULT_FONT_SIZE));
+    }
 
     if (isAlternate) {
         QFont nameFont = painter->font();
@@ -103,6 +109,7 @@ void AppListDelegate::paint(QPainter *painter, const QStyleOptionViewItem &optio
     }
 
     painter->drawText(textRect, Qt::AlignVCenter | Qt::AlignLeft, appName);
+    painter->setOpacity(1);
 
     // draw blue dot if needed
     if (index.data(AppsListModel::AppNewInstallRole).toBool() && !isAlternate && !isTitle) {


### PR DESCRIPTION
修正小窗口启动器下，分类标题的文字大小与颜色不正确的问题

Resolve https://github.com/linuxdeepin/developer-center/issues/3641

![image](https://user-images.githubusercontent.com/10095765/218698308-1ec8fac1-2b59-4348-b8c0-dce01852a638.png)
