### PR TITLE
fix: 当回收站发生变化时,调整只更新trash图标

### DIFF
--- a/src/model/appsmanager.cpp
+++ b/src/model/appsmanager.cpp
@@ -1419,6 +1419,7 @@ void AppsManager::refreshCategoryInfoList()
         bool bContains = fuzzyMatching(filters, info.m_key);
         if (!m_stashList.contains(info) && !bContains) {
             if (info.m_key == "dde-trash") {
+                m_trashItemInfo = info;
                 ItemInfo_v1 trashItem = info;
                 trashItem.m_iconKey = m_trashIsEmpty ? "user-trash" : "user-trash-full";
                 m_allAppInfoList.append(trashItem);
@@ -2051,6 +2052,12 @@ void AppsManager::updateTrashState()
     if (m_trashIsEmpty == !trashItemsCount)
         return;
 
-    m_trashIsEmpty = !trashItemsCount;
-    emit dataChanged(AppsListModel::FullscreenAll);
+    m_trashIsEmpty = !trashItemsCount;    
+    int index = itemIndex(m_windowedUsedSortedList, m_trashItemInfo);
+    
+    // 获取到trash,更新trash图标
+    if (index != -1) {
+        m_trashItemInfo.m_iconKey = m_trashIsEmpty ? "user-trash" : "user-trash-full";
+        m_windowedUsedSortedList[index].updateInfo(m_trashItemInfo);
+    }
 }

--- a/src/model/appsmanager.h
+++ b/src/model/appsmanager.h
@@ -272,6 +272,7 @@ private:
     int m_dirAppRow;                                                        // 应用文件夹所在的列表中的行数
     int m_dirAppPageIndex;                                                  // 从文件夹展开窗口移除应用时之前，文件夹所在页面索引
     ItemInfo_v1 m_clickedItemInfo;                                          // 当前被启动的应用
+    ItemInfo_v1 m_trashItemInfo;                                            // 回收站，用于直接更新回收站状态
 };
 
 #endif // APPSMANAGER_H


### PR DESCRIPTION
使用 m_trashItemInfo 对象用于直接更新trash图标变化,
而不是发送全部更新的信号
fix https://github.com/linuxdeepin/developer-center/issues/3778