### PR TITLE
fix(WindowedFrame): show one row when fav <= 4

### DIFF
--- a/src/fullscreenframe.cpp
+++ b/src/fullscreenframe.cpp
@@ -576,7 +576,7 @@ void FullScreenFrame::moveCurrentSelectApp(const int key)
             m_multiPagesView->showCurrentPage(curPage - 1);
         }
         auto model = m_multiPagesView->pageModel(m_multiPagesView->currentPage());
-        m_appItemDelegate->setCurrentIndex(m_multiPagesView->getAppItem(model->rowCount(QModelIndex()) - 1));
+        m_appItemDelegate->setCurrentIndex(m_multiPagesView->getAppItem(model->rowCount() - 1));
     } else if (index.isValid()) {
         // valid verify and UI adjustment.
         const QModelIndex selectedIndex = index.isValid() ? index : curModelIndex;

--- a/src/model/appslistmodel.cpp
+++ b/src/model/appslistmodel.cpp
@@ -352,7 +352,7 @@ int AppsListModel::rowCount(const QModelIndex &parent) const
 const QModelIndex AppsListModel::indexAt(const QString &desktopPath) const
 {
     int i = 0;
-    const int count = rowCount(QModelIndex());
+    const int count = rowCount();
     while (i < count) {
         if (index(i).data(AppDesktopRole).toString() == desktopPath)
             return index(i);
@@ -667,7 +667,7 @@ bool AppsListModel::indexDragging(const QModelIndex &index) const
 void AppsListModel::itemDataChanged(const ItemInfo_v1 &info)
 {
     int i = 0;
-    const int count = rowCount(QModelIndex());
+    const int count = rowCount();
     while (i != count) {
         if (index(i).data(AppKeyRole).toString() == info.m_key) {
             const QModelIndex modelIndex = index(i);

--- a/src/model/appslistmodel.h
+++ b/src/model/appslistmodel.h
@@ -101,7 +101,7 @@ public:
     void dropSwap(const int nextPos);
     inline QModelIndex dragDropIndex() const {return m_dragDropIndex;}
 
-    int rowCount(const QModelIndex &parent) const Q_DECL_OVERRIDE;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
     const QModelIndex indexAt(const QString &appKey) const;
 
     void setDrawBackground(bool draw);

--- a/src/view/appgridview.cpp
+++ b/src/view/appgridview.cpp
@@ -95,7 +95,7 @@ void AppGridView::dropEvent(QDropEvent *e)
         if (index.isValid()) {
             listModel->insertItem(info, index.row());
         } else {
-            listModel->insertItem(info, listModel->rowCount(QModelIndex()));
+            listModel->insertItem(info, listModel->rowCount());
         }
 
         listModel->clearDraggingIndex();
@@ -232,13 +232,11 @@ void AppGridView::dragMoveEvent(QDragMoveEvent *e)
     if (dropIndex.isValid()) {
         m_dropToPos = dropIndex.row();
     } else if (containerRect.contains(pos)) {
-        if (listModel) {
-            int lastRow = listModel->rowCount(QModelIndex()) - 1;
-            QModelIndex lastIndex = listModel->index(lastRow);
-            QPoint lastPos = indexRect(lastIndex).center();
-            if (pos.x() > lastPos.x() && pos.y() > lastPos.y())
-                m_dropToPos = lastIndex.row();
-        }
+        int lastRow = listModel->rowCount() - 1;
+        QModelIndex lastIndex = listModel->index(lastRow);
+        QPoint lastPos = indexRect(lastIndex).center();
+        if (pos.x() > lastPos.x() && pos.y() > lastPos.y())
+            m_dropToPos = lastIndex.row();
     }
 
     // 当文件夹展开窗口隐藏，当前显示的视图类型为 MainView 时，由于展开窗口的QDrag::exec() 其实未执行完毕，所以这里做了特殊处理，
@@ -482,7 +480,7 @@ QPixmap AppGridView::creatSrcPix(const QModelIndex &index)
         m_calendarWidget->hide();
         m_calendarWidget->setLayout(nullptr);
     } else {
-        srcPix = index.data(AppsListModel::AppDragIconRole).value<QPixmap>();
+        return index.data(AppsListModel::AppDragIconRole).value<QPixmap>();
     }
 
     return srcPix;

--- a/src/view/multipagesview.cpp
+++ b/src/view/multipagesview.cpp
@@ -212,7 +212,7 @@ void MultiPagesView::dragToLeft(const QModelIndex &index)
 
     showCurrentPage(m_pageIndex - 1);
 
-    int lastApp = m_pageAppsModelList[m_pageIndex]->rowCount(QModelIndex());
+    int lastApp = m_pageAppsModelList[m_pageIndex]->rowCount();
     QModelIndex firstModel = m_appGridViewList[m_pageIndex]->indexAt(lastApp - 1);
     m_appGridViewList[m_pageIndex]->dragIn(firstModel, m_pageSwitchAnimation->state() != QPropertyAnimation::Running);
 
@@ -245,7 +245,7 @@ void MultiPagesView::dragToRight(const QModelIndex &index)
     showCurrentPage(m_pageIndex + 1);
 
     // 将最后一个App'挤走'
-    int lastApp = m_pageAppsModelList[m_pageIndex]->rowCount(QModelIndex());
+    int lastApp = m_pageAppsModelList[m_pageIndex]->rowCount();
     QModelIndex lastModel = m_appGridViewList[m_pageIndex]->indexAt(lastApp - 1);
     m_appGridViewList[m_pageIndex]->dragIn(lastModel, m_pageSwitchAnimation->state() != QPropertyAnimation::Running);
 
@@ -400,7 +400,7 @@ QModelIndex MultiPagesView::selectApp(const int key)
             itemSelect = m_calcUtil->appPageItemCount(m_category) - 1;
         } else {
             page = m_pageCount - 1;
-            itemSelect = m_pageAppsModelList[page]->rowCount(QModelIndex()) - 1;
+            itemSelect = m_pageAppsModelList[page]->rowCount() - 1;
         }
     } else {
         if (page + 1 < m_pageCount) {
@@ -586,7 +586,7 @@ QSize MultiPagesView::calculateWidgetSize()
         if (!listModel)
             return QSize();
 
-        int itemCount = listModel->rowCount(QModelIndex());
+        int itemCount = listModel->rowCount();
         if (itemCount <= 3)
             viewWidth = itemWidth * 1 + leftMargin * 2;
         else if (itemCount <= 6)

--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -408,25 +408,33 @@ void WindowedFrame::searchAppState(bool searched)
     // 设置搜索状态
     setSearchState(searched);
 
-    // 收藏列表是否为空
-    const bool isFavoriteViewEmpty = (m_favoriteModel->rowCount(QModelIndex()) <= 0);
-
     // 搜索模式下只显示搜索控件,其他控件都不显示
     m_favoriteLabel->setVisible(!searched);
     m_favoriteView->setVisible(!searched);
 
-    const int height = m_appsView->height() / 2;
-    if (isFavoriteViewEmpty)
-        m_favoriteView->setFixedHeight(DLauncher::DEFAULT_VIEW_HEIGHT);
-    else
-        m_favoriteView->setFixedHeight(height);
-
-    m_emptyFavoriteWidget->setVisible(!searched && isFavoriteViewEmpty);
+    updateFavorateViewHeight(searched);
 
     m_allAppLabel->setVisible(!searched);
     m_allAppView->setVisible(!searched);
 
     m_searchWidget->setVisible(searched);
+}
+
+void WindowedFrame::updateFavorateViewHeight(bool searched)
+{
+    // 收藏列表是否为空
+    const int favRowCount = m_favoriteModel->rowCount();
+
+    if (favRowCount <= 0)
+        m_favoriteView->setFixedHeight(DLauncher::DEFAULT_VIEW_HEIGHT);
+    else if (favRowCount <= 4) {
+        m_favoriteView->setFixedHeight(CalculateUtil::instance()->appItemSize().height() +
+                                       CalculateUtil::instance()->appItemSpacing() * 3);
+    } else {
+        m_favoriteView->setFixedHeight(m_appsView->height() / 2);
+    }
+
+    m_emptyFavoriteWidget->setVisible(!searched && (favRowCount <= 0));
 }
 
 void WindowedFrame::showLauncher()
@@ -1458,24 +1466,13 @@ void WindowedFrame::onFavoriteListVisibleChaged()
     if (searchState())
         return;
 
-    const bool isFavoriteViewEmpty = (m_favoriteModel->rowCount(QModelIndex()) <= 0);
-
-    // 收藏列表为空时显示空页面
-    m_emptyFavoriteWidget->setVisible(isFavoriteViewEmpty);
-
-    // 收藏列表
-    const int height = m_appsView->height() / 2;
-
-    if (isFavoriteViewEmpty)
-        m_favoriteView->setFixedHeight(DLauncher::DEFAULT_VIEW_HEIGHT);
-    else
-        m_favoriteView->setFixedHeight(height);
+    updateFavorateViewHeight(false);
 }
 
 void WindowedFrame::onLayoutChanged()
 {
-    if (m_calcUtil->fullscreen()) {
-        qDebug() << "now in the WindowedFrame";
+    if (!visible()) {
+        qDebug() << "not in the WindowedFrame";
         return;
     }
 

--- a/src/windowedframe.h
+++ b/src/windowedframe.h
@@ -83,6 +83,7 @@ private:
     void initConnection();
     void setAccessibleName();
     void searchAppState(bool searched = false);
+    void updateFavorateViewHeight(bool searched);
 
     void showLauncher() override;
     void hideLauncher() override;


### PR DESCRIPTION
当收藏的应用不多于 4 个时，仅展示一行高度的收藏区域。

Resolve https://github.com/linuxdeepin/dde-launcher/issues/380