### PR TITLE
Fix: Explicitly close QFile jianpinFile

### DIFF
--- a/src/global_util/languagetranformation.cpp
+++ b/src/global_util/languagetranformation.cpp
@@ -103,6 +103,7 @@ void LanguageTransformation::readConfigFile()
 
         QString jianpinStr = jianpinFile.readAll();
         m_jianpingStrList.append(jianpinStr);
+        jianpinFile.close();
 //        qInfo() << "m_jianpingStrList: " << m_jianpingStrList;
     });
 }


### PR DESCRIPTION
Fix: 显式关闭jianpinFile文件

尽管QFile会在对象超出范围时调用析构函数来自动关闭文件，但显式关闭文件是一种很好的做法，以防止将来潜在的代码更改风险。在src/global_util/languagetranformation.cpp文件中readConfigFile（）函数文件中：pinYinFile正常关闭，而文件jianpinFile没有关闭，故添加关闭操作

log: Apr 15, 2023