### PR TITLE
fix: avoid moving window to the void when dock dbus is missing

### DIFF
--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -1292,7 +1292,11 @@ void WindowedFrame::adjustPosition()
     }
 
     initAnchoredCornor();
-    move(launcherPoint);
+
+    // Can be empty when dde-dock d-bus is missing or in some debug environment.
+    if (!dockRect.isEmpty()) {
+        move(launcherPoint);
+    }
 }
 
 void WindowedFrame::onToggleFullScreen()


### PR DESCRIPTION
当获取 dde-dock 位置的 dbus 无法返回正确信息时，不尝试将 launcher
移动到无效的位置。
