### PR TITLE
chore: release 6.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-launcher (6.0.11) unstable; urgency=medium
+
+  * Avoid setting invalid font weight to QFont
+  * Avoid moving window to invalid place when certain dbus is missing
+  * Raise up pixmap cache limit to 64800 KiB
+  * Fix duplicate icons may be shown after update launcher
+
+ -- Wang Zichong <wangzichong@deepin.org>  Mon, 08 May 2023 13:54:00 +0800
+
 dde-launcher (6.0.10) unstable; urgency=medium
 
   * Update documentation


### PR DESCRIPTION
Changelog:

  * Avoid setting invalid font weight to QFont
  * Avoid moving window to invalid place when certain dbus is missing
  * Raise up pixmap cache limit to 64800 KiB
  * Fix duplicate icons may be shown after update launcher
