### PR TITLE
fix: icons will be added repeatedly

### DIFF
--- a/src/model/appsmanager.cpp
+++ b/src/model/appsmanager.cpp
@@ -1409,8 +1409,14 @@ const QString AppsManager::appName(const ItemInfo_v1 &info, const int size)
 
 void AppsManager::updateDataFromAllAppList(ItemInfoList_v1 &processList)
 {
+    ItemInfoList_v1 dirAppInfoList;
+    for (const ItemInfo_v1 &itemInfo : processList) {
+        if (itemInfo.m_isDir)
+            dirAppInfoList.append(itemInfo.m_appInfoList);
+    }
+
     for (const ItemInfo_v1 &itemInfo : m_allAppInfoList) {
-        if (!contains(processList, itemInfo)) {
+        if (!contains(processList, itemInfo) && !contains(dirAppInfoList, itemInfo)) {
             processList.append(itemInfo);
         } else {
             // 多语言时，更新应用信息


### PR DESCRIPTION
从m_allAppInfoList更新数据时，应该同时检查该应用是否已经被拖到文件夹中。
如果已在文件夹中，不会在m_fullscreenUsedSortedList直接检索到，此时不应该添加该数据。
