### PR TITLE
fix: incorrect trash status when deleting file in other partition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ find_package(Dtk REQUIRED COMPONENTS Core Widget Gui)
 
 pkg_check_modules(XCB_EWMH REQUIRED IMPORTED_TARGET xcb-ewmh)
 pkg_check_modules(QGSettings REQUIRED IMPORTED_TARGET gsettings-qt)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
 
 set(XML2CPP_DIR ${PROJECT_SOURCE_DIR}/src/global_util/dbus/xml2cpp)
 
@@ -130,6 +131,23 @@ generation_dbus_interface(
     ${CMAKE_SOURCE_DIR}/xml/org.deepin.dde.XEventMonitor1.xml
     XEventMonitor
     ${XML2CPP_DIR}/xeventmonitor_interface
+)
+
+add_library(trashutils
+OBJECT
+    src/trashutils/trashmonitor.h
+    src/trashutils/trashmonitor.cpp
+)
+
+target_link_libraries(trashutils
+PUBLIC
+    Qt5::Core
+    PkgConfig::GIO
+)
+
+target_compile_definitions(trashutils
+PRIVATE
+    QT_NO_KEYWORDS
 )
 
 include_directories(
@@ -206,6 +224,7 @@ target_link_libraries(${BIN_NAME} PRIVATE
     Qt5::Svg
     Qt5::GuiPrivate
     PkgConfig::QGSettings
+    trashutils
 )
 
 ## qm files

--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,8 @@ Build-Depends:
  libdtkgui-dev (>=5.4.13),
  libgsettings-qt-dev,
  libgtest-dev,
- libgmock-dev
+ libgmock-dev,
+ libglib2.0-dev
 Standards-Version: 3.9.8
 Homepage: http://www.deepin.org/
 

--- a/src/model/appslistmodel.cpp
+++ b/src/model/appslistmodel.cpp
@@ -212,7 +212,6 @@ AppsListModel::AppsListModel(const AppCategory &category, QObject *parent)
     , m_pageIndex(0)
 {
     connect(m_appsManager, &AppsManager::dataChanged, this, &AppsListModel::dataChanged);
-    connect(m_appsManager, &AppsManager::layoutChanged, this, &AppsListModel::layoutChanged);
     connect(m_appsManager, &AppsManager::itemDataChanged, this, &AppsListModel::itemDataChanged);
 }
 

--- a/src/model/appsmanager.cpp
+++ b/src/model/appsmanager.cpp
@@ -1644,6 +1644,13 @@ void AppsManager::refreshItemInfoList()
     // 移除收藏列表中不存在的应用
     // 更新应用信息
     for (ItemInfo_v1 &info : m_favoriteSortedList) {
+        if (info.m_key == "dde-trash") {
+            // blumia: It's possible the icon is changed by appsmanager (the user-trash one).
+            //         This is definitely not the correct approach.
+            //         As a workaround, we also update the icon key here.
+            info.m_iconKey = m_trashIsEmpty ? "user-trash" : "user-trash-full";
+        }
+
         if (!contains(m_allAppInfoList, info)) {
             m_favoriteSortedList.removeOne(info);
         } else {

--- a/src/model/appsmanager.h
+++ b/src/model/appsmanager.h
@@ -12,6 +12,8 @@
 #include "amdbuslauncherinterface.h"
 #include "amdbusdockinterface.h"
 
+#include "trashutils/trashmonitor.h"
+
 #include <DGuiApplicationHelper>
 #include <DDialog>
 
@@ -115,7 +117,6 @@ public:
 signals:
     void itemDataChanged(const ItemInfo_v1 &info) const;
     void dataChanged(const AppsListModel::AppCategory category) const;
-    void layoutChanged(const AppsListModel::AppCategory category) const;
     void requestTips(const QString &tips) const;
     void requestHideTips() const;
     void categoryListChanged() const;
@@ -185,6 +186,7 @@ private:
     void getCategoryListAndSortCategoryId();
     void refreshCategoryInfoList();
     void refreshItemInfoList();
+    void updateTrashIconFromInfoList();
     void saveAppCategoryInfoList();
     void generateCategoryMap();
     void generateTitleCategoryList();
@@ -258,7 +260,7 @@ private:
     bool m_iconValid;                                                       // 获取图标状态标示
 
     bool m_trashIsEmpty;
-    QFileSystemWatcher *m_fsWatcher;
+    TrashMonitor *m_trashMonitor;
 
     QTimer *m_updateCalendarTimer;
     bool m_uninstallDlgIsShown;
@@ -274,7 +276,6 @@ private:
     int m_dirAppRow;                                                        // 应用文件夹所在的列表中的行数
     int m_dirAppPageIndex;                                                  // 从文件夹展开窗口移除应用时之前，文件夹所在页面索引
     ItemInfo_v1 m_clickedItemInfo;                                          // 当前被启动的应用
-    ItemInfo_v1 m_trashItemInfo;                                            // 回收站，用于直接更新回收站状态
 };
 
 #endif // APPSMANAGER_H

--- a/src/trashutils/trashmonitor.cpp
+++ b/src/trashutils/trashmonitor.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "trashmonitor.h"
+
+TrashMonitor::TrashMonitor(QObject *parent)
+    : QObject(parent)
+    , m_trash(g_file_new_for_uri("trash:///"))
+    , m_trashMonitor(g_file_monitor_file(m_trash, G_FILE_MONITOR_NONE, NULL, NULL))
+{
+    g_signal_connect(m_trashMonitor, "changed", G_CALLBACK(slot_onTrashMonitorChanged), this);
+}
+
+TrashMonitor::~TrashMonitor()
+{
+    g_object_unref(m_trashMonitor);
+    g_object_unref(m_trash);
+}
+
+int TrashMonitor::trashItemCount()
+{
+    GFileInfo *info;
+    gint file_count = 0;
+
+    info = g_file_query_info(m_trash, G_FILE_ATTRIBUTE_TRASH_ITEM_COUNT, G_FILE_QUERY_INFO_NONE, NULL, NULL);
+    if (info != NULL) {
+        file_count = g_file_info_get_attribute_uint32(info, G_FILE_ATTRIBUTE_TRASH_ITEM_COUNT);
+        g_object_unref(info);
+    }
+
+    return file_count;
+}
+
+void TrashMonitor::onTrashMonitorChanged(GFileMonitor *monitor, GFile *file, GFile *other_file, GFileMonitorEvent event_type)
+{
+    Q_UNUSED(monitor)
+    Q_UNUSED(file)
+    Q_UNUSED(other_file)
+
+    if (event_type == G_FILE_MONITOR_EVENT_ATTRIBUTE_CHANGED) {
+        Q_EMIT trashAttributeChanged();
+    }
+}
+
+void TrashMonitor::slot_onTrashMonitorChanged(GFileMonitor *monitor, GFile *file,
+                                         GFile *other_file, GFileMonitorEvent event_type,
+                                         gpointer user_data)
+{
+    TrashMonitor * that = reinterpret_cast<TrashMonitor*>(user_data);
+    that->onTrashMonitorChanged(monitor, file, other_file, event_type);
+}

--- a/src/trashutils/trashmonitor.h
+++ b/src/trashutils/trashmonitor.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+
+#undef signals
+#include <gio/gio.h>
+#define signals Q_SIGNALS
+
+class TrashMonitor: public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit TrashMonitor(QObject * parent);
+    ~TrashMonitor();
+
+    int trashItemCount();
+
+Q_SIGNALS:
+    void trashAttributeChanged();
+
+private:
+    GFile * m_trash;
+    GFileMonitor * m_trashMonitor;
+
+    void onTrashMonitorChanged(GFileMonitor *monitor, GFile *file, GFile *other_file, GFileMonitorEvent event_type);
+    static void slot_onTrashMonitorChanged(GFileMonitor *monitor, GFile *file, GFile *other_file, GFileMonitorEvent event_type, gpointer user_data);
+};


### PR DESCRIPTION
The old implementation only monitor the trash folder in user's partition, thus the trash folder in other partition will not trached. It will cause the launcher icon status out-of-sync with the real trash status.

This patch switch to use gio to monitor the trash status (might need to port to dtkio when it get a stable release).

Issue: https://github.com/linuxdeepin/developer-center/issues/4478
Log: Fix the trash icon status might out-of-sync in some cases