### PR TITLE
fix: onAppearanceChanged use mistake type

### DIFF
--- a/src/boxframe/backgroundmanager.cpp
+++ b/src/boxframe/backgroundmanager.cpp
@@ -140,7 +140,7 @@ void BackgroundManager::onAppearanceChanged(const QString &type, const QString &
 {
     Q_UNUSED(str);
 
-    if (type == "background")
+    if (type == "allwallpaperuris")
         updateBlurBackgrounds();
 }
 


### PR DESCRIPTION
launcher background use desktop wallpaper, should associate "allwallpaperuris" type

Log: fix the problem that the background image did not follow the change when switching the theme
Resolve: https://github.com/linuxdeepin/developer-center/issues/3663