### PR TITLE
feat: uninstall app in launcher

### DIFF
--- a/src/model/appsmanager.h
+++ b/src/model/appsmanager.h
@@ -135,8 +135,8 @@ public slots:
     void saveCollectedSortedList();
     void searchApp(const QString &keywords);
     void launchApp(const QModelIndex &index);
-    void uninstallApp(const QString &desktopPath);
-    void uninstallApp(const ItemInfo_v1 &info);
+    void uninstallApp(const QString &name, bool isLinglong = false);
+//    void uninstallApp(const ItemInfo_v1 &info);
     void onEditCollected(const QModelIndex index, const bool isInCollected);
     void onMoveToFirstInCollected(const QModelIndex index);
     void setDirAppInfoList(const QModelIndex index);


### PR DESCRIPTION
适配 AM 重构，卸载应用在 launcher 中实现
原 AM 逻辑适配：
- 玲珑应用 ll-cli uninstall $appid
- 其他应用 lastore RemovePackage (需要把launcher加入白名单