### PR TITLE
chore: modify interface name of PropertiesChanged signal

### DIFF
--- a/src/dbusinterface/aminterface.cpp
+++ b/src/dbusinterface/aminterface.cpp
@@ -633,7 +633,7 @@ ApplicationDBusProxy::ApplicationDBusProxy(const QString &path, QObject *parent)
     : QObject(parent)
     , m_applicationDBus(new DDBusInterface(AMServiceName, path, AMInterfaceName, QDBusConnection::sessionBus(), this))
 {
-    QDBusConnection::sessionBus().connect(AMServiceName, path, APPInterfaceName,
+    QDBusConnection::sessionBus().connect(AMServiceName, path, "org.freedesktop.DBus.Properties",
                                           "PropertiesChanged", "sa{sv}as", this,
                                           SLOT(onPropertiesChanged(const QDBusMessage&)));
 }

--- a/src/dbusinterface/aminterface.h
+++ b/src/dbusinterface/aminterface.h
@@ -10,7 +10,6 @@
 #include <QObject>
 
 #include <DDBusInterface>
-#include <DFileWatcher>
 
 DCORE_USE_NAMESPACE
 
@@ -158,7 +157,6 @@ private:
     AppManagerDBusProxy *m_objManagerDbusInter;
     QMap<QString, ItemInfo_v3> m_infos;
     QStringList m_autoStartApps;
-    DFileWatcher *m_autoStartFileWather;
 };
 
 #endif


### PR DESCRIPTION
change the interface name to "org.freedesktop.DBus.Properties"

Log: modify interface name of PropertiesChanged signal