### PR TITLE
refact: clean code on appsmanager

### DIFF
--- a/src/model/appslistmodel.cpp
+++ b/src/model/appslistmodel.cpp
@@ -268,7 +268,7 @@ void AppsListModel::insertItem(int pos)
 {
     beginInsertRows(QModelIndex(), pos, pos);
 
-    pos += m_appsManager->getPageIndex() * m_calcUtil->appPageItemCount(m_appsManager->getCategory());
+    pos += m_appsManager->pageIndex() * m_calcUtil->appPageItemCount(m_appsManager->category());
 
     m_appsManager->insertDropItem(pos);
     endInsertRows();
@@ -293,7 +293,7 @@ void AppsListModel::dropSwap(const int nextPos)
     const ItemInfo_v1 &appInfo = m_dragStartIndex.data(AppsListModel::AppRawItemInfoRole).value<ItemInfo_v1>();
 
     // 从文件夹展开窗口移除应用时，文件夹本身不执行移动操作
-    if (m_appsManager->getDragMode() != AppsManager::DirOut) {
+    if (m_appsManager->dragMode() != AppsManager::DirOut) {
         removeRows(m_dragStartIndex.row(), 1, QModelIndex());
         dropInsert(appInfo.m_desktop, nextPos);
     }

--- a/src/model/appsmanager.h
+++ b/src/model/appsmanager.h
@@ -1,41 +1,23 @@
-// SPDX-FileCopyrightText: 2017 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2017 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef APPSMANAGER_H
 #define APPSMANAGER_H
 
-#include "appslistmodel.h"
-#include "dbustartmanager.h"
-#include "calculate_util.h"
-#include "common.h"
-#include "amdbuslauncherinterface.h"
-#include "amdbusdockinterface.h"
-
 #include "trashutils/trashmonitor.h"
+#include "appslistmodel.h"
+#include "iteminfo.h"
 
 #include <DGuiApplicationHelper>
-#include <DDialog>
-
-#include <QHash>
-#include <QSettings>
-#include <QPixmap>
-#include <QTimer>
-#include <QApplication>
-#include <QDesktopWidget>
-#include <QScreen>
-#include <QList>
 
 DGUI_USE_NAMESPACE
 
-#define LEFT_PADDING 200
-#define RIGHT_PADDING 200
-
-#define MAX_VIEW_NUM    255
-#define CATEGORY_COUNT    11
-
 class CalculateUtil;
 class AppGridView;
+class DBusStartManager;
+class AMDBusDockInter;
+class AMDBusLauncherInter;
 
 class AppsManager : public QObject
 {
@@ -59,11 +41,9 @@ public:
     bool isVaild();
     void refreshAllList();
     int getPageCount(const AppsListModel::AppCategory category);
-    const QScreen * currentScreen();
+    const QScreen *currentScreen();
     int getVisibleCategoryCount();
     bool fullscreen() const;
-    int displayMode() const;
-    qreal getCurRatio();
     void uninstallApp(const QModelIndex &modelIndex);
     bool uninstallDlgShownState() const;
 
@@ -74,42 +54,32 @@ public:
     const ItemInfo_v1 getItemInfo(const QString &desktop);
     void dropToCollected(const ItemInfo_v1 &info, const int row);
 
-    static bool readJsonFile(QIODevice &device, QSettings::SettingsMap &map);
-    static bool writeJsonFile(QIODevice &device, const QSettings::SettingsMap &map);
-    void registerSettingsFormat();
-
-    QSettings::SettingsMap getCacheMapData(const ItemInfoList_v1 &list);
-    const ItemInfoList_v1 readCacheData(const QSettings::SettingsMap &map);
-
     void setDragMode(const DragMode &mode);
-    DragMode getDragMode() const;
-
-    void setRemainedLastItem(const ItemInfo_v1 &info);
-    const ItemInfo_v1 getRemainedLastItem() const;
+    DragMode dragMode() const;
 
     void setDirAppRow(const int &row);
-    int getDirAppRow() const;
+    int dirAppRow() const;
 
     void setDirAppPageIndex(const int &pageIndex);
-    int getDirAppPageIndex() const;
+    int dirAppPageIndex() const;
 
     void setDragItem(const ItemInfo_v1 &info);
-    const ItemInfo_v1 getDragItem() const;
+    const ItemInfo_v1 dragItem() const;
 
     void setReleasePos(const int &row);
-    int getReleasePos() const;
+    int releasePos() const;
 
     void setCategory(const AppsListModel::AppCategory category);
-    AppsListModel::AppCategory getCategory() const;
+    AppsListModel::AppCategory category() const;
 
     void setPageIndex(const int &pageIndex);
-    int getPageIndex() const;
+    int pageIndex() const;
 
     void setListModel(AppsListModel *model);
-    AppsListModel *getListModel() const;
+    AppsListModel *listModel() const;
 
     void setListView(AppGridView *view);
-    AppGridView *getListView() const;
+    AppGridView *listView() const;
 
     void setDragModelIndex(const QModelIndex &index);
     QModelIndex dragModelIndex() const;
@@ -197,6 +167,13 @@ private:
     void setAutostartValue(const QStringList &list);
     QStringList getAutostartValue() const;
 
+    void registerSettingsFormat();
+    QSettings::SettingsMap getCacheMapData(const ItemInfoList_v1 &list);
+    const ItemInfoList_v1 readCacheData(const QSettings::SettingsMap &map);
+
+    void setRemainedLastItem(const ItemInfo_v1 &info);
+    const ItemInfo_v1 remainedLastItem() const;
+
 private slots:
     void markLaunched(const QString &appKey);
     void delayRefreshData();
@@ -227,8 +204,6 @@ private:
     QStringList m_newInstalledAppsList;                                     // 新安装应用列表
 
     ItemInfoList_v1 m_stashList;
-    ItemInfo_v1 m_unInstallItem;
-    ItemInfo_v1 m_beDragedItem;
 
     CalculateUtil *m_calUtil;
     QTimer *m_delayRefreshTimer;                                            // 延迟刷新应用列表定时器指针对象

--- a/src/view/appgridview.cpp
+++ b/src/view/appgridview.cpp
@@ -593,14 +593,14 @@ void AppGridView::startDrag(const QModelIndex &index, bool execDrag)
                 listModel->dropSwap(indexAt(m_dragStartPos).row());
 
             // TODO: 搜索模式下的会新增一个控件，因此这里暂时删除针对搜索模式的业务，不影响主体功能
-            int releasePos = AppsManager::instance()->getReleasePos();
+            int releasePos = AppsManager::instance()->releasePos();
 
 #ifdef QT_DEBUG
-            qDebug() << "releasePos: " << releasePos << ", dragMode: " << m_appManager->getDragMode();
+            qDebug() << "releasePos: " << releasePos << ", dragMode: " << m_appManager->dragMode();
 #endif
-            if (m_appManager->getListModel() && m_appManager->getDragMode() == AppsManager::DirOut) {
-                m_appManager->getListModel()->insertItem(releasePos);
-                m_appManager->getListModel()->clearDraggingIndex();
+            if (m_appManager->listModel() && m_appManager->dragMode() == AppsManager::DirOut) {
+                m_appManager->listModel()->insertItem(releasePos);
+                m_appManager->listModel()->clearDraggingIndex();
             }
 
             listModel->clearDraggingIndex();
@@ -659,21 +659,21 @@ void AppGridView::startDrag(const QModelIndex &index, bool execDrag)
         posAni->setEndValue(mapToGlobal(m_dropPoint) + QPoint(m_calcUtil->appMarginLeft(), 0));
     } else if (getViewType() == PopupView && m_calcUtil->fullscreen()) {
         // 全屏模式下，文件夹展开窗口中的应用被拖拽释放后...
-        int releasePos = AppsManager::instance()->getReleasePos();
+        int releasePos = AppsManager::instance()->releasePos();
 
         // 这里进行坐标计算时，不需要对页码进行计算，因为动画仅仅在当前页面进行展示，所以不需要进行考虑页码对动画起点和终点的影响
         // releasePos += m_appManager->getPageIndex() * m_calcUtil->appPageItemCount(m_appManager->getCategory());
-        if (!m_appManager->getListView()) {
+        if (!m_appManager->listView()) {
             qDebug() << "destination listview ptr is null...";
             return;
         }
 
-        QModelIndex itemIndex = m_appManager->getListView()->indexAt(releasePos);
-        QRect itemRect = m_appManager->getListView()->indexRect(itemIndex);
-        QPoint endPos = m_appManager->getListView()->mapToGlobal(itemRect.topLeft());
+        QModelIndex itemIndex = m_appManager->listView()->indexAt(releasePos);
+        QRect itemRect = m_appManager->listView()->indexRect(itemIndex);
+        QPoint endPos = m_appManager->listView()->mapToGlobal(itemRect.topLeft());
         posAni->setEndValue(endPos + QPoint(m_calcUtil->appMarginLeft(), 0));
 #ifdef QT_DEBUG
-        qDebug() << "releasePos:" << releasePos << ", model index valid status:" << itemIndex.isValid() << ", itemRect:" << itemRect << ", mapToGlobal:" << m_appManager->getListView()->mapToGlobal(itemRect.center());
+        qDebug() << "releasePos:" << releasePos << ", model index valid status:" << itemIndex.isValid() << ", itemRect:" << itemRect << ", mapToGlobal:" << m_appManager->listView()->mapToGlobal(itemRect.center());
 #endif
     } else {
         m_pixLabel->hide();

--- a/src/windowedframe.cpp
+++ b/src/windowedframe.cpp
@@ -7,6 +7,7 @@
 #include "dbusdockinterface.h"
 #include "constants.h"
 #include "appitemdelegate.h"
+#include "amdbusdockinterface.h"
 #include "aminterface.h"
 
 #include <DWindowManagerHelper>

--- a/src/worker/menuworker.cpp
+++ b/src/worker/menuworker.cpp
@@ -8,6 +8,7 @@
 #include "amdbuslauncherinterface.h"
 #include "amdbusdockinterface.h"
 #include "aminterface.h"
+#include "calculate_util.h"
 
 #include <QSignalMapper>
 #include <QWindow>


### PR DESCRIPTION
1. remove unused headers and members;
2. rename member functions;
3. change public interfaces to private interfaces;

Log: clean code on appsmanager