### PR TITLE
chore: not test mouse point if launcher is hidden

### DIFF
--- a/src/launchersys.cpp
+++ b/src/launchersys.cpp
@@ -223,6 +223,9 @@ void LauncherSys::onFrontendRectChanged()
 
 void LauncherSys::onButtonPress(const QPoint &p, const int flag)
 {
+    if (!m_launcherInter->visible())
+        return;
+
     m_launcherInter->regionMonitorPoint(p, flag);
 }
 


### PR DESCRIPTION
RegionMonitorPoint will list all forign windows and test if mouse is clicked 'onboard'