### PR TITLE
chore: release dde-launcher 6.0.19

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-launcher (6.0.19) unstable; urgency=medium
+
+  * fix: declare conflict with dde-launchpad
+  * fix: logout timeout
+
+ -- Wang Zichong <wangzichong@deepin.org>  Fri, 22 Dec 2023 14:34:00 +0800
+
 dde-launcher (6.0.18) unstable; urgency=medium
 
   * chore: initialize member value explicitly


### PR DESCRIPTION
此 tag release 旨在解决技术预览插件无法从 launchpad 切换回 launcher 的问题。

涉及两个 Issue：

- https://github.com/linuxdeepin/developer-center/issues/5330 
  - （对应集成 https://github.com/linuxdeepin/developer-center/issues/6527 ）
- https://github.com/linuxdeepin/developer-center/issues/6516
  - （关联集成 https://github.com/linuxdeepin/developer-center/issues/6538 ）